### PR TITLE
Add Electron multi-arch/cross-compilation support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -157,18 +157,23 @@ Dynamic symbol files are also available in the `out/` directory for each framewo
 
 To build the Node.js module suitable for including in an Electron app, run:
 
-    make electron PLATFORM=<platform>
+    make electron PLATFORM=<platform> NODEJS_ARCH=<arch>
 
 where platform can be:
 - `mac` or `ios` (either of these can be used the MacOS)
 - `unix` or `android` (either of these can be used for Linux)
 - `windows`
 
-This will produce a release build for the host architecture (we don't support cross-compiling Electron builds at this time).
+and where the (optional) `NODEJS_ARCH` can be:
+- `x64`
+- `ia32`
+- `arm64`
+
+If no `NODEJS_ARCH` is provided, the build script will default to `x64`. Note that architectures other than `x64` are currently only supported through cross-compilation. That is, compiling for `arm64` on a `x64` machine works, but compiling for `arm64` on an `arm64` machine is not currently supported.
 
 When the build is complete, the library will be available here:
 
-    src/node/build/<platform>/libringrtc.node
+    src/node/build/<platform>/libringrtc-<arch>.node
 
 ### CLI test tool
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ ANDROID_TARGETS := $(foreach t, $(BUILD_TYPES),     \
 
 IOS_TARGETS := ios/release
 
+# This can be overriden on the command line, e.g. "make electron NODEJS_ARCH=ia32"
+# Note: make sure to only use NodeJS architectures here, like x64, ia32, arm64, etc.
+NODEJS_ARCH := x64
+
 help:
 	$(Q) echo "The following build targets are supported:"
 	$(Q) echo "  ios      -- download WebRTC and build for the iOS platform"
@@ -74,10 +78,10 @@ electron:
 	fi
 	$(Q) if [ "$(TYPE)" = "debug" ] ; then \
 		echo "Electron: Debug build" ; \
-		./bin/build-electron -d ; \
+		TARGET_ARCH=$(NODEJS_ARCH) ./bin/build-electron -d ; \
 	else \
 		echo "Electron: Release build" ; \
-		./bin/build-electron -r ; \
+		TARGET_ARCH=$(NODEJS_ARCH) ./bin/build-electron -r ; \
 	fi
 	$(Q) (cd src/node && yarn install && yarn build)
 

--- a/bin/build-electron
+++ b/bin/build-electron
@@ -10,6 +10,9 @@ set -e
 BIN_DIR="$(realpath -e $(dirname $0))"
 . "${BIN_DIR}/env.sh"
 
+# Note: make sure to only use NodeJS architectures here, like x64, ia32, arm64, etc.
+TARGET_ARCH=${TARGET_ARCH:-x64}
+
 usage()
 {
     echo 'usage: build-electron [-d|-r|-c]
@@ -56,31 +59,50 @@ while [ "$1" != "" ]; do
     shift
 done
 
-get_default_platform()
-{
-    hash rustup 2>/dev/null || { echo >&2 "Make sure you have rustup installed and properly configured! Aborting."; exit 1; }
+case "$TARGET_ARCH" in
+    "x64")
+        GN_ARCH=x64
+        CARGO_ARCH=x86_64
+        ;;
+    "ia32")
+        GN_ARCH=x86
+        CARGO_ARCH=i686
+        ;;
+    "arm64")
+        GN_ARCH=arm64
+        CARGO_ARCH=aarch64
+        ;;
+    *)
+        echo "Unsupported architecture"
+        exit 1
+        ;;
+esac
 
-    case "$(rustup show active-toolchain)" in 
-        *"x86_64-apple-darwin"* )
-            echo "darwin"
-            ;;
-        *"x86_64-pc-windows"* )
-            echo "win32"
-            ;;
-        *"x86_64-unknown-linux"* )
-            echo "linux"
-            ;;
-        * )
-            echo "unknown"
-    esac
-}
+hash rustup 2>/dev/null || { echo >&2 "Make sure you have rustup installed and properly configured! Aborting."; exit 1; }
 
-DEFAULT_PLATFORM=$(get_default_platform)
-if [ "${DEFAULT_PLATFORM}" = "unknown" ]
-then
-    echo "Unknown platform detected!\nPlease make sure you have installed a valid Rust toolchain via rustup! Aborting."
-    exit 1
-fi
+RUSTFLAGS_WIN=
+
+case "$(rustup show active-toolchain)" in 
+    *"x86_64-apple-darwin"* )
+        DEFAULT_PLATFORM="darwin"
+        CARGO_TARGET="${CARGO_ARCH}-apple-darwin"
+        ;;
+    *"x86_64-pc-windows"* )
+        DEFAULT_PLATFORM="win32"
+        CARGO_TARGET="${CARGO_ARCH}-pc-windows-msvc"
+        # Static linking to prevent build errors on Windows ia32
+        RUSTFLAGS_WIN="-C target-feature=+crt-static"
+        ;;
+    *"x86_64-unknown-linux"* )
+        DEFAULT_PLATFORM="linux"
+        CARGO_TARGET="${CARGO_ARCH}-unknown-linux-gnu"
+        ;;
+    * )
+        echo "Unknown platform detected!\nPlease make sure you have installed a valid Rust toolchain via rustup! Aborting."
+        exit 1
+esac
+
+echo "Building for platform ${DEFAULT_PLATFORM}, TARGET_ARCH=${TARGET_ARCH}, GN_ARCH=${GN_ARCH}, CARGO_TARGET=${CARGO_TARGET}"
 
 export MACOSX_DEPLOYMENT_TARGET="10.10"
 
@@ -90,10 +112,10 @@ export MACOSX_DEPLOYMENT_TARGET="10.10"
 
     if [ "${BUILD_TYPE}" = "debug" ]
     then
-        gn gen -C "${OUTPUT_DIR}"/debug "--args=use_custom_libcxx=false rtc_build_examples=false rtc_build_tools=false rtc_include_tests=false rtc_enable_protobuf=false rtc_use_x11=false rtc_enable_sctp=false"
+        gn gen -C "${OUTPUT_DIR}"/debug "--args=use_custom_libcxx=false target_cpu=\"${GN_ARCH}\" rtc_build_examples=false rtc_build_tools=false rtc_include_tests=false rtc_enable_protobuf=false rtc_use_x11=false rtc_enable_sctp=false"
         ninja -C "${OUTPUT_DIR}"/debug
     else
-        gn gen -C "${OUTPUT_DIR}"/release "--args=use_custom_libcxx=false rtc_build_examples=false rtc_build_tools=false rtc_include_tests=false rtc_enable_protobuf=false rtc_use_x11=false rtc_enable_sctp=false is_debug=false"
+        gn gen -C "${OUTPUT_DIR}"/release "--args=use_custom_libcxx=false target_cpu=\"${GN_ARCH}\" rtc_build_examples=false rtc_build_tools=false rtc_include_tests=false rtc_enable_protobuf=false rtc_use_x11=false rtc_enable_sctp=false is_debug=false"
         ninja -C "${OUTPUT_DIR}"/release
     fi
 )
@@ -104,22 +126,22 @@ export MACOSX_DEPLOYMENT_TARGET="10.10"
 
     if [ "${BUILD_TYPE}" = "debug" ]
     then
-        npm_config_arch=x64 npm_config_target_arch=x64 npm_config_disturl=https://atom.io/download/electron npm_config_runtime=electron npm_config_target=11.2.0 npm_config_build_from_source=true npm_config_devdir=~/.electron-gyp OUTPUT_DIR="${OUTPUT_DIR}" cargo build --features electron
+        npm_config_arch=${TARGET_ARCH} npm_config_target_arch=${TARGET_ARCH} npm_config_disturl=https://atom.io/download/electron npm_config_runtime=electron npm_config_target=11.2.0 npm_config_build_from_source=true npm_config_devdir=~/.electron-gyp RUSTFLAGS="${RUSTFLAGS_WIN}" OUTPUT_DIR="${OUTPUT_DIR}" cargo build --target ${CARGO_TARGET} --features electron
     else
-        npm_config_arch=x64 npm_config_target_arch=x64 npm_config_disturl=https://atom.io/download/electron npm_config_runtime=electron npm_config_target=11.2.0 npm_config_build_from_source=true npm_config_devdir=~/.electron-gyp RUSTFLAGS="-C link-arg=-s" OUTPUT_DIR="${OUTPUT_DIR}" cargo build --features electron --release
+        npm_config_arch=${TARGET_ARCH} npm_config_target_arch=${TARGET_ARCH} npm_config_disturl=https://atom.io/download/electron npm_config_runtime=electron npm_config_target=11.2.0 npm_config_build_from_source=true npm_config_devdir=~/.electron-gyp RUSTFLAGS="-C link-arg=-s ${RUSTFLAGS_WIN}" OUTPUT_DIR="${OUTPUT_DIR}" cargo build --target ${CARGO_TARGET} --features electron --release
     fi
 
     if [ $DEFAULT_PLATFORM = "darwin" ]
     then
         mkdir -p ../node/build/darwin
-        cp -f target/${BUILD_TYPE}/libringrtc.dylib ../node/build/darwin/libringrtc.node
+        cp -f target/${CARGO_TARGET}/${BUILD_TYPE}/libringrtc.dylib ../node/build/darwin/libringrtc-${TARGET_ARCH}.node
     elif [ $DEFAULT_PLATFORM = "win32" ]
     then
         mkdir -p ../node/build/win32
-        cp -f target/${BUILD_TYPE}/ringrtc.dll ../node/build/win32/libringrtc.node
+        cp -f target/${CARGO_TARGET}/${BUILD_TYPE}/ringrtc.dll ../node/build/win32/libringrtc-${TARGET_ARCH}.node
     elif [ $DEFAULT_PLATFORM = "linux" ]
     then
         mkdir -p ../node/build/linux
-        cp -f target/${BUILD_TYPE}/libringrtc.so ../node/build/linux/libringrtc.node
+        cp -f target/${CARGO_TARGET}/${BUILD_TYPE}/libringrtc.so ../node/build/linux/libringrtc-${TARGET_ARCH}.node
     fi
 )

--- a/src/node/ringrtc/Service.ts
+++ b/src/node/ringrtc/Service.ts
@@ -5,10 +5,11 @@
 
 /* tslint:disable max-classes-per-file */
 
-const os = require('os');
+import * as os from 'os';
+import * as process from 'process';
 
 // tslint:disable-next-line no-var-requires no-require-imports
-const Native = require('../../build/' + os.platform() + '/libringrtc.node');
+const Native = require('../../build/' + os.platform() + '/libringrtc-' + process.arch + '.node');
 
 // tslint:disable-next-line no-unnecessary-class
 class NativeCallManager {

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -590,9 +590,9 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "neon"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a171c5739a277a667669678475165bdbaec1769010e167706c365fd2f98d4f39"
+checksum = "9e98cdd7a8f84ad67b8b3b15806a2972914533d3af7e4ec32cb24e3a101955b9"
 dependencies = [
  "cslice",
  "neon-build",
@@ -604,15 +604,15 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c4ddb734e07eeb082b1db7e94b47efd385a3672229ca758a2e2c128263db7f"
+checksum = "40aa98b2816150f1b0e4f9283b6cb8df101aba9a5e8c5facba32e607e80bedac"
 
 [[package]]
 name = "neon-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48258a462ac1d9e35c99205588b19af8dca6be8a1a7a97a064be8f402de45f25"
+checksum = "7c8b046fb631a0e57e785342e8ebe0597554779a805956e24e6c525a2441ae1a"
 dependencies = [
  "quote",
  "syn",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "neon-runtime"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c2ae6cb6d5f5a546f5f43dc0318ae90c237b8c0fd30364e299abb7e5cda913"
+checksum = "cdde3dee10a83057034f65c7a1e73dc595f111c16d7e4ae123c57fa7f065e86a"
 dependencies = [
  "cfg-if 1.0.0",
  "libloading",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -49,7 +49,7 @@ simplelog   = { version = "0.7", optional = true, default-features = false }
 rand_chacha = { version = "0.2", optional = true }
 
 # Optional, needed by the "electron" feature
-neon = { version = "0.7.0", optional = true, default-features = false, features = ["napi-1"] }
+neon = { version = "0.7.1", optional = true, default-features = false, features = ["napi-1"] }
 
 # Optional, needed to check Android-specific code when not targeting Android
 jni = { version = "0.17.0", optional = true, default-features = false }


### PR DESCRIPTION
Now that ringrtc has switched to `neon`'s N-API backend, we can cross-compile to different architectures for Electron 🎉  This PR adds support for building ia32 and arm64. Please note that this still only supports building from a x64 host.

This work is related to https://github.com/signalapp/Signal-Desktop/issues/3745 and https://github.com/signalapp/Signal-Desktop/issues/4461.

You can test this by running `make electron NODEJS_ARCH=arm64`. Supported archs are `x64`, `ia32`, `arm64` (in line with NodeJS' archs), default is x64.

**Tested on:**
- [x] darwin x64 (build + yarn test)
- [x] darwin arm64 (build)
- [x] windows x64 (build + yarn test)
- [x] windows arm64 (build + yarn test)
- [x] windows ia32 (build)
- [x] linux x64 (build + yarn test)
- [x] linux arm64 (build)
- [x] linux ia32 (build)

## MacOS (darwin) arm64 / Apple Silicon
~MacOS (darwin) arm64 doesn't seem to work yet~ **FIXED** ✔️: https://github.com/signalapp/ringrtc/pull/12#issuecomment-830689652