### PR TITLE
Fix warnings and clippy warnings

### DIFF
--- a/src/rust/src/android/android_platform.rs
+++ b/src/rust/src/android/android_platform.rs
@@ -413,7 +413,7 @@ impl Platform for AndroidPlatform {
         // Offers are always broadcast
         // TODO: Simplify Java's onSendOffer method to assume broadcast
         let broadcast = true;
-        let receiver_device_id = 0 as DeviceId;
+        let receiver_device_id = 0;
 
         info!("on_send_offer(): call_id: {}", call_id);
 
@@ -421,7 +421,7 @@ impl Platform for AndroidPlatform {
         let jni_call_manager = self.jni_call_manager.as_obj();
 
         // Set a frame capacity of min (5) + objects (3).
-        let capacity = (8) as i32;
+        let capacity = 8;
         let _ = env.with_local_frame(capacity, || {
             let jni_remote = remote_peer.as_obj();
             let call_id_jlong = u64::from(call_id) as jlong;
@@ -496,7 +496,7 @@ impl Platform for AndroidPlatform {
         let jni_call_manager = self.jni_call_manager.as_obj();
 
         // Set a frame capacity of min (5) + objects (2).
-        let capacity = (7) as i32;
+        let capacity = 7;
         let _ = env.with_local_frame(capacity, || {
             let jni_remote = remote_peer.as_obj();
             let call_id_jlong = u64::from(call_id) as jlong;
@@ -547,7 +547,7 @@ impl Platform for AndroidPlatform {
     ) -> Result<()> {
         let (broadcast, receiver_device_id) = match send.receiver_device_id {
             // The DeviceId doesn't matter if we're broadcasting
-            None => (true, 0 as DeviceId),
+            None => (true, 0),
             Some(receiver_device_id) => (false, receiver_device_id),
         };
 
@@ -636,7 +636,7 @@ impl Platform for AndroidPlatform {
         // Hangups are always broadcast
         // TODO: Simplify Java's onSendHangup method to assume broadcast
         let broadcast = true;
-        let receiver_device_id = 0 as DeviceId;
+        let receiver_device_id = 0;
 
         info!("on_send_hangup(): call_id: {}", call_id);
 
@@ -650,7 +650,7 @@ impl Platform for AndroidPlatform {
         let (hangup_type, hangup_device_id) = send.hangup.to_type_and_device_id();
         // We set the device_id to 0 in case it is not defined. It will
         // only be used for hangup types other than Normal.
-        let hangup_device_id = hangup_device_id.unwrap_or(0 as DeviceId) as jint;
+        let hangup_device_id = hangup_device_id.unwrap_or(0) as jint;
         let jni_hangup_type =
             match self.java_enum(&env, CALL_MANAGER_CLASS, "HangupType", hangup_type as i32) {
                 Ok(v) => AutoLocal::new(&env, v),
@@ -687,7 +687,7 @@ impl Platform for AndroidPlatform {
         // Busy messages are always broadcast
         // TODO: Simplify Java's onSendBusy method to assume broadcast
         let broadcast = true;
-        let receiver_device_id = 0 as DeviceId;
+        let receiver_device_id = 0;
 
         info!("on_send_busy(): call_id: {}", call_id);
 
@@ -725,7 +725,7 @@ impl Platform for AndroidPlatform {
         let jni_call_manager = self.jni_call_manager.as_obj();
 
         // Set a frame capacity of min (5) + objects (2).
-        let capacity = (7) as i32;
+        let capacity = 7;
         env.with_local_frame(capacity, || {
             let jni_recipient_uuid = JObject::from(env.byte_array_from_slice(&recipient_uuid)?);
             let jni_message = JObject::from(env.byte_array_from_slice(&message)?);

--- a/src/rust/src/android/logging.rs
+++ b/src/rust/src/android/logging.rs
@@ -59,10 +59,7 @@ impl Log for AndroidLogger {
                 Err(_) => return,
             };
 
-            let path = match record.module_path() {
-                Some(v) => v,
-                None => "unknown",
-            };
+            let path = record.module_path().unwrap_or("unknown");
 
             let level = record.level() as i32;
 

--- a/src/rust/src/core/call_fsm.rs
+++ b/src/rust/src/core/call_fsm.rs
@@ -570,7 +570,7 @@ where
             | CallState::ConnectedWithDataChannelBeforeAccepted = state
             {
                 let (_hangup_type, hangup_device_id) = hangup_to_propagate.to_type_and_device_id();
-                let excluded_remote_device_id = hangup_device_id.unwrap_or(0 as DeviceId);
+                let excluded_remote_device_id = hangup_device_id.unwrap_or(0);
                 call.send_hangup_via_data_channel_and_signaling_to_all_except(
                     hangup_to_propagate,
                     excluded_remote_device_id,

--- a/src/rust/src/core/call_manager.rs
+++ b/src/rust/src/core/call_manager.rs
@@ -2183,8 +2183,9 @@ where
         debug!("  recipient: {}", uuid_to_string(&recipient));
 
         let platform = self.platform.lock().expect("platform.lock()");
-        let mut call_message = protobuf::signaling::CallMessage::default();
-        call_message.group_call_message = Some(message);
+        let call_message = protobuf::signaling::CallMessage {
+            group_call_message: Some(message)
+        };
         let mut bytes = BytesMut::with_capacity(call_message.encoded_len());
         let result = call_message.encode(&mut bytes);
         match result {

--- a/src/rust/src/core/connection.rs
+++ b/src/rust/src/core/connection.rs
@@ -989,9 +989,10 @@ where
             .peer_connection()?
             .set_max_send_bitrate(combined_max)?;
 
-        let mut receiver_status = protobuf::data_channel::ReceiverStatus::default();
-        receiver_status.id = Some(u64::from(self.call_id));
-        receiver_status.max_bitrate_bps = Some(local_max.as_bps());
+        let receiver_status = protobuf::data_channel::ReceiverStatus {
+            id: Some(u64::from(self.call_id)),
+            max_bitrate_bps: Some(local_max.as_bps()),
+        };
 
         let data_channel = webrtc.data_channel().ok();
         self.update_and_send_dcm_state_via_data_channel(data_channel, move |data| {
@@ -1190,10 +1191,11 @@ where
 
         let (hangup_type, hangup_device_id) = hangup.to_type_and_device_id();
 
-        let mut hangup = protobuf::data_channel::Hangup::default();
-        hangup.id = Some(u64::from(self.call_id));
-        hangup.r#type = Some(hangup_type as i32);
-        hangup.device_id = hangup_device_id;
+        let hangup = protobuf::data_channel::Hangup {
+            id: Some(u64::from(self.call_id)),
+            r#type: Some(hangup_type as i32),
+            device_id: hangup_device_id,
+        };
 
         let webrtc = self.webrtc.lock()?;
         let data_channel = webrtc.data_channel().ok();
@@ -1211,8 +1213,9 @@ where
             format!("dc(accepted)\t{}", self.connection_id)
         );
 
-        let mut accepted = protobuf::data_channel::Accepted::default();
-        accepted.id = Some(u64::from(self.call_id));
+        let accepted = protobuf::data_channel::Accepted {
+            id: Some(u64::from(self.call_id)),
+        };
 
         let webrtc = self.webrtc.lock()?;
         let data_channel = webrtc.data_channel().ok();
@@ -1229,9 +1232,10 @@ where
     /// * `video_enabled` - `true` when the local side is streaming video,
     /// otherwise `false`.
     pub fn send_sender_status_via_data_channel(&self, video_enabled: bool) -> Result<()> {
-        let mut sender_status = protobuf::data_channel::SenderStatus::default();
-        sender_status.id = Some(u64::from(self.call_id));
-        sender_status.video_enabled = Some(video_enabled);
+        let sender_status = protobuf::data_channel::SenderStatus {
+            id: Some(u64::from(self.call_id)),
+            video_enabled: Some(video_enabled),
+        };
 
         let webrtc = self.webrtc.lock()?;
         let data_channel = webrtc.data_channel().ok();

--- a/src/rust/src/core/signaling.rs
+++ b/src/rust/src/core/signaling.rs
@@ -192,14 +192,15 @@ impl Offer {
         v3_or_v2_sdp: String,
         v1_sdp: String,
     ) -> Result<Self> {
-        let mut offer_proto_v3_or_v2 = protobuf::signaling::ConnectionParametersV3OrV2::default();
-        offer_proto_v3_or_v2.public_key = Some(public_key);
-        offer_proto_v3_or_v2.sdp = Some(v3_or_v2_sdp);
+        let offer_proto_v3_or_v2 = protobuf::signaling::ConnectionParametersV3OrV2 {
+            public_key: Some(public_key),
+            sdp: Some(v3_or_v2_sdp),
+        };
 
-        let mut offer_proto = protobuf::signaling::Offer::default();
-        offer_proto.v3_or_v2 = Some(offer_proto_v3_or_v2);
-
-        offer_proto.v4 = v4;
+        let offer_proto = protobuf::signaling::Offer {
+            v3_or_v2: Some(offer_proto_v3_or_v2),
+            v4,
+        };
 
         let mut opaque = BytesMut::with_capacity(offer_proto.encoded_len());
         offer_proto.encode(&mut opaque)?;
@@ -370,8 +371,10 @@ impl Answer {
 
     // V4 == V3 + non-SDP; V3 == V2 + public key
     pub fn from_v4(v4: protobuf::signaling::ConnectionParametersV4) -> Result<Self> {
-        let mut proto = protobuf::signaling::Answer::default();
-        proto.v4 = Some(v4);
+        let proto = protobuf::signaling::Answer {
+            v4: Some(v4),
+            ..Default::default()
+        };
 
         let mut opaque = BytesMut::with_capacity(proto.encoded_len());
         proto.encode(&mut opaque)?;
@@ -381,12 +384,15 @@ impl Answer {
 
     // V3 == V2 + public key
     pub fn from_v3_and_v2_sdp(public_key: Vec<u8>, v3_and_v2_sdp: String) -> Result<Self> {
-        let mut answer_proto_v3_or_v2 = protobuf::signaling::ConnectionParametersV3OrV2::default();
-        answer_proto_v3_or_v2.public_key = Some(public_key);
-        answer_proto_v3_or_v2.sdp = Some(v3_and_v2_sdp);
+        let answer_proto_v3_or_v2 = protobuf::signaling::ConnectionParametersV3OrV2 {
+            public_key: Some(public_key),
+            sdp: Some(v3_and_v2_sdp),
+        };
 
-        let mut answer_proto = protobuf::signaling::Answer::default();
-        answer_proto.v3_or_v2 = Some(answer_proto_v3_or_v2);
+        let answer_proto = protobuf::signaling::Answer {
+            v3_or_v2: Some(answer_proto_v3_or_v2),
+            ..Default::default()
+        };
 
         let mut opaque = BytesMut::with_capacity(answer_proto.encoded_len());
         answer_proto.encode(&mut opaque)?;
@@ -483,11 +489,13 @@ impl IceCandidate {
 
     // ICE candidates are the same for V1 and V2 and V3.
     pub fn from_v3_and_v2_and_v1_sdp(sdp: String) -> Result<Self> {
-        let mut ice_candidate_proto_v3_or_v2 = protobuf::signaling::IceCandidateV3OrV2::default();
-        ice_candidate_proto_v3_or_v2.sdp = Some(sdp.clone());
+        let ice_candidate_proto_v3_or_v2 = protobuf::signaling::IceCandidateV3OrV2 {
+            sdp: Some(sdp.clone()),
+        };
 
-        let mut ice_candidate_proto = protobuf::signaling::IceCandidate::default();
-        ice_candidate_proto.v3_or_v2 = Some(ice_candidate_proto_v3_or_v2);
+        let ice_candidate_proto = protobuf::signaling::IceCandidate {
+            v3_or_v2: Some(ice_candidate_proto_v3_or_v2),
+        };
 
         let mut opaque = BytesMut::with_capacity(ice_candidate_proto.encoded_len());
         ice_candidate_proto.encode(&mut opaque)?;


### PR DESCRIPTION
There were some unnecessary casts that were generating warning. There were
also some clippy warnings mostly related to initializing structs in an
un-idiomatic way.