### PR TITLE
Add FUNDING.yml to display sponsor button in GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Copyright 2021 Signal Messenger, LLC
+# SPDX-License-Identifier: AGPL-3.0-only
+
+custom: https://signal.org/donate/


### PR DESCRIPTION
Displays the _Sponsor_ button on top of the GitHub interface, which redirects to https://signal.org/donate/. This file is similar to the [FUNDING.yml](https://github.com/signalapp/Signal-Desktop/blob/development/.github/FUNDING.yml) file on the Signal-Desktop and Signal-iOS repositories.

![Screenshot_600](https://user-images.githubusercontent.com/15776622/105225594-19ee4b00-5b5f-11eb-9a4c-07ee4de56726.png)