### PR TITLE
Bump resolution from 720p to 1080p

### DIFF
--- a/src/ios/SignalRingRTC/SignalRingRTC/CallManager.swift
+++ b/src/ios/SignalRingRTC/SignalRingRTC/CallManager.swift
@@ -458,8 +458,8 @@ public class CallManager<CallType, CallManagerDelegateType>: CallManagerInterfac
 
         // Define maximum output video format for 1:1 calls.
         videoSource.adaptOutputFormat(
-            toWidth: 1280,
-            height: 720,
+            toWidth: 1920,
+            height: 1080,
             fps: 30
         )
 

--- a/src/ios/SignalRingRTC/SignalRingRTC/VideoCaptureController.swift
+++ b/src/ios/SignalRingRTC/SignalRingRTC/VideoCaptureController.swift
@@ -9,8 +9,8 @@ import SignalCoreKit
 @available(iOSApplicationExtension, unavailable)
 public class VideoCaptureController {
     // The maximum video format allowable for any type of call.
-    static let maxCaptureWidth: Int32 = 1280
-    static let maxCaptureHeight: Int32 = 720
+    static let maxCaptureWidth: Int32 = 1920
+    static let maxCaptureHeight: Int32 = 1080
     static let maxCaptureFrameRate: Int32 = 30
 
     private let capturer = RTCCameraVideoCapturer()

--- a/src/rust/src/gctc.rs
+++ b/src/rust/src/gctc.rs
@@ -330,8 +330,8 @@ fn main() {
 
     std::thread::spawn(move || {
         for index in 0u64.. {
-            let width = 1280;
-            let height = 720;
+            let width = 1920;
+            let height = 1080;
             let rgba_data: Vec<u8> = (0..(width * height * 4))
                 .map(|i: u32| i.wrapping_add(index as u32) as u8)
                 .collect();


### PR DESCRIPTION
Signal video call quality is limited to 720p. FaceTime currently offers way better quality with 1080p Video calling over WiFi or 5G. I would like to see the same for Signal Messenger as it would a really compelling feature to have.
I'm not sure if other code changes accros the various code bases would be needed to bring this feature alive.

Trying to make Signal better :)