### PR TITLE
deps: fetch build artefacts using a proxy where necessary

### DIFF
--- a/src/node/package.json
+++ b/src/node/package.json
@@ -29,6 +29,7 @@
   "author": "",
   "license": "AGPL-3.0-only",
   "dependencies": {
+    "https-proxy-agent": "^7.0.2",
     "tar": "^6.1.0"
   },
   "devDependencies": {

--- a/src/node/package.json
+++ b/src/node/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "AGPL-3.0-only",
   "dependencies": {
-    "https-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "7.0.1",
     "tar": "^6.1.0"
   },
   "devDependencies": {

--- a/src/node/scripts/fetch-prebuild.js
+++ b/src/node/scripts/fetch-prebuild.js
@@ -6,6 +6,7 @@
 /* eslint-disable no-console */
 
 const https = require('https');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -51,7 +52,15 @@ async function downloadIfNeeded() {
 function download() {
   console.log(`downloading ${URL}`);
   return new Promise((resolve, reject) => {
-    https.get(URL, async res => {
+    let options = {};
+    if (process.env.HTTPS_PROXY != undefined) {
+      options.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+    }
+    if (process.env.https_proxy != undefined) {
+      options.agent = new HttpsProxyAgent(process.env.https_proxy);
+    }
+
+    https.get(URL, options, async res => {
       try {
         const out = fs.createWriteStream(tmpFile);
 

--- a/src/node/scripts/fetch-prebuild.js
+++ b/src/node/scripts/fetch-prebuild.js
@@ -56,10 +56,6 @@ function download() {
     if (process.env.HTTPS_PROXY != undefined) {
       options.agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
     }
-    if (process.env.https_proxy != undefined) {
-      options.agent = new HttpsProxyAgent(process.env.https_proxy);
-    }
-
     https.get(URL, options, async res => {
       try {
         const out = fs.createWriteStream(tmpFile);

--- a/src/node/yarn.lock
+++ b/src/node/yarn.lock
@@ -399,6 +399,13 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
+agent-base@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.0.tgz#536802b76bc0b34aa50195eb2442276d613e3434"
+  integrity sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==
+  dependencies:
+    debug "^4.3.4"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -836,7 +843,7 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
-debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1770,6 +1777,14 @@ http2-wrapper@^1.0.0-beta.5.2:
   dependencies:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
+
+https-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
+  integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "4"
 
 ignore@^5.2.0:
   version "5.2.4"

--- a/src/node/yarn.lock
+++ b/src/node/yarn.lock
@@ -1778,10 +1778,10 @@ http2-wrapper@^1.0.0-beta.5.2:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
 
-https-proxy-agent@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
-  integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
+https-proxy-agent@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz#0277e28f13a07d45c663633841e20a40aaafe0ab"
+  integrity sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==
   dependencies:
     agent-base "^7.0.2"
     debug "4"


### PR DESCRIPTION
I've been struggling to build Signal from source where the build machine is behind a proxy.

This change will have no effect during build unless the `HTTPS_PROXY` variable is set, in which case it establishes an agent that will ensure the `https.get` calls use the proxy correctly.

I'm open to suggestions on a different approach if the addition of another dependency is too undesirable.