### PR TITLE
Bump libsignal tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "libsignal-core"
 version = "0.1.0"
-source = "git+https://github.com/signalapp/libsignal?tag=v0.37.0#d47f96abff97d19a0b125376737655c268dd20b9"
+source = "git+https://github.com/signalapp/libsignal?tag=v0.51.0#95bf4e77155b5110e80a8d140cce7adaef8aa0ac"
 dependencies = [
  "num_enum 0.6.1",
  "uuid",
@@ -1780,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "poksho"
 version = "0.7.0"
-source = "git+https://github.com/signalapp/libsignal?tag=v0.37.0#d47f96abff97d19a0b125376737655c268dd20b9"
+source = "git+https://github.com/signalapp/libsignal?tag=v0.51.0#95bf4e77155b5110e80a8d140cce7adaef8aa0ac"
 dependencies = [
  "curve25519-dalek",
  "hmac 0.12.1",
@@ -1947,6 +1972,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2323,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "signal-crypto"
 version = "0.1.0"
-source = "git+https://github.com/signalapp/libsignal?tag=v0.37.0#d47f96abff97d19a0b125376737655c268dd20b9"
+source = "git+https://github.com/signalapp/libsignal?tag=v0.51.0#95bf4e77155b5110e80a8d140cce7adaef8aa0ac"
 dependencies = [
  "aes",
  "cbc",
@@ -3260,22 +3305,26 @@ dependencies = [
 [[package]]
 name = "zkcredential"
 version = "0.1.0"
-source = "git+https://github.com/signalapp/libsignal?tag=v0.37.0#d47f96abff97d19a0b125376737655c268dd20b9"
+source = "git+https://github.com/signalapp/libsignal?tag=v0.51.0#95bf4e77155b5110e80a8d140cce7adaef8aa0ac"
 dependencies = [
+ "cfg-if",
  "curve25519-dalek",
  "derive-where",
  "displaydoc",
  "lazy_static",
  "partial-default",
  "poksho",
+ "rayon",
  "serde",
+ "sha2 0.10.8",
  "subtle",
+ "thiserror",
 ]
 
 [[package]]
 name = "zkgroup"
 version = "0.9.0"
-source = "git+https://github.com/signalapp/libsignal?tag=v0.37.0#d47f96abff97d19a0b125376737655c268dd20b9"
+source = "git+https://github.com/signalapp/libsignal?tag=v0.51.0#95bf4e77155b5110e80a8d140cce7adaef8aa0ac"
 dependencies = [
  "aes-gcm-siv",
  "bincode",
@@ -3287,12 +3336,16 @@ dependencies = [
  "hkdf 0.12.4",
  "lazy_static",
  "libsignal-core",
+ "num_enum 0.6.1",
  "partial-default",
  "poksho",
+ "rand",
+ "rayon",
  "serde",
  "sha2 0.10.8",
  "signal-crypto",
  "subtle",
+ "thiserror",
  "uuid",
  "zkcredential",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -65,7 +65,7 @@ x25519-dalek      = { version = "2.0.1", features = ["static_secrets"] }
 # libsignal-client.
 bincode = { version = "1.3.3" }
 uuid = { version = "1.8.0", optional = true }
-zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.37.0" }
+zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.51.0" }
 
 # Optional, needed by the "electron" feature
 neon = { version = "1.0.0", optional = true, default-features = false, features = ["napi-6"] }


### PR DESCRIPTION
As described in #55, libsignal is tracked by git tag, which introduces conflicts when pulling the latest (currently 0.51) libsignal in a project together with ringrtc (which points to 0.37). As long as the zkgroup implementation is compatible (or physically the same), this doesn't materialize as an actual problem on the Signal products.