### PR TITLE
Run Linux arm64 build and tests on native CI runners

### DIFF
--- a/.github/workflows/ringrtc.yml
+++ b/.github/workflows/ringrtc.yml
@@ -99,25 +99,17 @@ jobs:
     - name: Run rust tests
       run: cd src/rust && ./scripts/run-tests
 
-  aarch64_cross:
-    name: Cross compile Linux aarch64 (using prebuilt WebRTC)
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler crossbuild-essential-arm64 libpulse-dev
-    - uses: actions/checkout@v4
-    - run: rustup target add aarch64-unknown-linux-gnu
-    - run: ./bin/fetch-artifact --platform linux-arm64 --release -o out-arm
-    - run: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc TARGET_ARCH=arm64 OUTPUT_DIR=out-arm ./bin/build-electron --ringrtc-only --release
-
   electron:
     name: Electron Tests
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-13]
+        os: [ubuntu-22.04, windows-latest, macos-13, ubuntu-22.04-arm]
         include:
         - os: ubuntu-22.04
+          install-deps: sudo add-apt-repository ppa:pipewire-debian/pipewire-upstream && sudo apt-get update && sudo apt-get install -y protobuf-compiler libpulse-dev libpulse0 pipewire && systemctl --user daemon-reload && systemctl --user --now enable pipewire pipewire-pulse
+          test-runner: xvfb-run --auto-servernum
+        - os: ubuntu-22.04-arm
           install-deps: sudo add-apt-repository ppa:pipewire-debian/pipewire-upstream && sudo apt-get update && sudo apt-get install -y protobuf-compiler libpulse-dev libpulse0 pipewire && systemctl --user daemon-reload && systemctl --user --now enable pipewire pipewire-pulse
           test-runner: xvfb-run --auto-servernum
         - os: windows-latest
@@ -153,9 +145,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-latest]
+        os: [ubuntu-22.04, macos-13, windows-latest, ubuntu-22.04-arm]
         include:
         - os: ubuntu-22.04
+          install-deps: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpulse-dev
+        - os: ubuntu-22.04-arm
           install-deps: sudo apt-get update && sudo apt-get install -y protobuf-compiler libpulse-dev
         - os: macos-13
           install-deps: brew install protobuf coreutils

--- a/bin/build-electron
+++ b/bin/build-electron
@@ -97,9 +97,11 @@ case "$TARGET_ARCH" in
         GN_ARCH=x86
         CARGO_ARCH=i686
         ;;
-    "arm64")
+    "arm64"|"aarch64")
         GN_ARCH=arm64
         CARGO_ARCH=aarch64
+        # Normalize TARGET_ARCH to arm64
+        TARGET_ARCH=arm64
         ;;
     *)
         echo "Unsupported architecture"


### PR DESCRIPTION
In https://github.com/signalapp/ringrtc/issues/59#issuecomment-2477269159, the following was mentioned:

> I suspect there is a bug in a dependency we're linking against when cross-compiling for aarch64 linux on an x64 linux box (which is how we produce the aarch64 build of ringrtc), and I have a theory of what the bug is.
> 
> I do not have an aarch64 linux device at hand, so it's a bit challenging to test, but I will try to see if any colleagues have one.

GitHub [now offers](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) hosted Linux arm64 runners, so it's possible to build and test natively on this architecture. This PR updates the CI pipeline accordingly.