### PR TITLE
Set `libyuv_use_sme` to false on Linux arm64 to fix `undefined symbol` error on ARMv8 devices

### DIFF
--- a/bin/build-electron
+++ b/bin/build-electron
@@ -133,6 +133,15 @@ then
         WEBRTC_ARGS="${WEBRTC_ARGS} is_debug=false symbol_level=1"
     fi
 
+    # SME requires the ARMv9-A architecture, while most ARM64 devices are ARMv8. This was causing
+    # "undefined symbol: __arm_tpidr2_save" errors on such devices, including GitHub's ubuntu-22.04-arm runner.
+    # https://issuetracker.google.com/issues/359006069
+    # https://chromium.googlesource.com/libyuv/libyuv/+/61354d2671d9b5c73cc964415fe25bc76cea051a/BUILD.gn#273
+    if [ "$(uname)" = "Linux" ] && [ "${TARGET_ARCH}" = "arm64" ]
+    then
+      WEBRTC_ARGS="${WEBRTC_ARGS} libyuv_use_sme=false"
+    fi
+
     (
         cd src/webrtc/src
         gn gen -C "${OUTPUT_DIR}/${BUILD_TYPE}" "--args=${WEBRTC_ARGS}"


### PR DESCRIPTION
This fixes the `undefined symbol: __arm_tpidr2_save` error on Linux arm64 that was reported in https://github.com/signalapp/ringrtc/pull/61#issuecomment-2634470748.

Without this fix, the pipeline [fails](https://github.com/dennisameling/ringrtc/actions/runs/13452043555/job/37588096731).

I built `6834d` with the fix included (artifacts are [here](https://github.com/dennisameling/ringrtc/releases)). This results in a [green CI build](https://github.com/dennisameling/ringrtc/actions/runs/13452267961/job/37588698501) on Linux arm64 🎉 