### PR TITLE
Remove workaround for XDG_RUNTIME_DIR missing on Linux arm64 runner

### DIFF
--- a/.github/workflows/ringrtc.yml
+++ b/.github/workflows/ringrtc.yml
@@ -112,13 +112,6 @@ jobs:
       run:
         shell: bash # as opposed to PowerShell
     steps:
-    # See https://github.com/actions/partner-runner-images/issues/53
-    - name: Work around XDG_RUNTIME_DIR error on Linux arm64 larger runner
-      if: matrix.os == 'ubuntu-22.04-arm64-4-cores'
-      run: |
-        echo "UID is $UID. Setting XDG_RUNTIME_DIR to /run/user/$UID"
-        sudo systemctl start user@$UID.service
-        echo "XDG_RUNTIME_DIR=/run/user/$UID" >> $GITHUB_ENV
     - name: Install dependencies
       run: |
         if [[ "${{ matrix.os }}" == macos-* ]]; then


### PR DESCRIPTION
The upstream issue has been resolved and the workaround is therefore no longer needed: https://github.com/actions/runner-images/issues/14092